### PR TITLE
Improve unit tests for ApiKeyUtils

### DIFF
--- a/src/test/java/com/epam/ta/reportportal/auth/ApiKeyUtilsTest.java
+++ b/src/test/java/com/epam/ta/reportportal/auth/ApiKeyUtilsTest.java
@@ -24,9 +24,21 @@ import org.springframework.stereotype.Component;
 /**
  * @author <a href="mailto:ihar_kahadouski@epam.com">Ihar Kahadouski</a>
  */
+import org.apache.commons.codec.digest.DigestUtils;
+import org.junit.jupiter.api.Test;
+import org.springframework.stereotype.Component;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.junit.jupiter.api.Assertions.*;
+
 @Component
 class ApiKeyUtilsTest {
-
 
   @Test
   void validToken() {
@@ -41,6 +53,76 @@ class ApiKeyUtilsTest {
   @Test
   void invalidToken() {
     assertFalse(ApiKeyUtils.validateToken("test2_bCV0dcQfRuCo0Eq1Uv2_hizk4pHnssbsGAQxTQ1_gWJaX0kVHPM"));
+  }
+
+  @Test
+  void invalidUUIDToken() {
+    assertFalse(ApiKeyUtils.validateToken("c229070a-56fe-4f99-ad57-fa945aa9443z")); // Invalid character 'z'
+  }
+
+  @Test
+  void shortToken() {
+    assertFalse(ApiKeyUtils.validateToken("short_token"));
+  }
+
+  @Test
+  void longToken() {
+    assertFalse(ApiKeyUtils.validateToken("this_is_a_very_long_token_that_should_not_be_valid"));
+  }
+
+  @Test
+  void emptyToken() {
+    assertFalse(ApiKeyUtils.validateToken(""));
+  }
+
+  @Test
+  void nullToken() {
+    assertThrows(NullPointerException.class, () -> ApiKeyUtils.validateToken(null));
+  }
+
+  @Test
+  void validBase64Token() {
+    assertTrue(ApiKeyUtils.validateToken("dGVzdF9iQ1YwZGNRekZ1Q28wRXExVXYyX2hpems0cEhu"));
+  }
+
+  @Test
+  void invalidBase64Token() {
+    assertFalse(ApiKeyUtils.validateToken("dGVzdF9iQ1YwZGNRekZ1Q28wRXExVXYyX2hpems0cEhu_invalid"));
+  }
+
+  @Test
+  void validTokenWithDifferentLength() {
+    assertTrue(ApiKeyUtils.validateToken("test2_bCV0dcQfRuCo0Eq1Uv2_hizk4pHnssmV6qMLCEHGcyabsGAQxTQ1_gWJaX0kVHPM"));
+  }
+
+  @Test
+  void validTokenWithDifferentCharacters() {
+    assertTrue(ApiKeyUtils.validateToken("test2_bCV0dcQfRuCo0Eq1Uv2_hizk4pHnssmV6qMLCEHGcyabsGAQxTQ1_gWJaX0kVHPM"));
+  }
+
+  @Test
+  void invalidTokenWithSpecialCharacters() {
+    assertFalse(ApiKeyUtils.validateToken("test2_bCV0dcQfRuCo0Eq1Uv2_hizk4pHnssmV6qMLCEHGcyabsGAQxTQ1_gWJaX0kVHPM!@#"));
+  }
+
+  @Test
+  void validTokenWithUnderscore() {
+    assertTrue(ApiKeyUtils.validateToken("test2_bCV0dcQfRuCo0Eq1Uv2_hizk4pHnssmV6qMLCEHGcyabsGAQxTQ1_gWJaX0kVHPM"));
+  }
+
+  @Test
+  void invalidTokenWithUnderscore() {
+    assertFalse(ApiKeyUtils.validateToken("test2_bCV0dcQfRuCo0Eq1Uv2_hizk4pHnssmV6qMLCEHGcyabsGAQxTQ1_gWJaX0kVHPM_"));
+  }
+
+  @Test
+  void validTokenWithMixedCase() {
+    assertTrue(ApiKeyUtils.validateToken("test2_bCV0dcQfRuCo0Eq1Uv2_hizk4pHnssmV6qMLCEHGcyabsGAQxTQ1_gWJaX0kVHPM"));
+  }
+
+  @Test
+  void invalidTokenWithMixedCase() {
+    assertFalse(ApiKeyUtils.validateToken("test2_bCV0dcQfRuCo0Eq1Uv2_hizk4pHnssmV6qMLCEHGcyabsGAQxTQ1_gWJaX0kVHPM"));
   }
 
 }


### PR DESCRIPTION
Enhanced the unit tests for the ApiKeyUtils class to cover more edge cases and ensure better test coverage. Added tests for invalid UUID tokens, short tokens, long tokens, empty tokens, null tokens, valid and invalid Base64 tokens, tokens with special characters, and tokens with mixed cases.