### PR TITLE
Add unit tests for ItemInfoUtils

### DIFF
--- a/src/test/java/com/epam/ta/reportportal/util/ItemInfoUtilsTest.java
+++ b/src/test/java/com/epam/ta/reportportal/util/ItemInfoUtilsTest.java
@@ -21,10 +21,15 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.epam.ta.reportportal.entity.ItemAttribute;
 import com.epam.ta.reportportal.ws.reporting.ItemAttributeResource;
+import com.epam.ta.reportportal.ws.reporting.BulkInfoUpdateRQ;
+import com.epam.ta.reportportal.ws.reporting.UpdateItemAttributeRQ;
+import com.epam.reportportal.rules.exception.ReportPortalException;
 import com.google.common.collect.Lists;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
+import java.util.HashSet;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -40,8 +45,7 @@ class ItemInfoUtilsTest {
 
   @Test
   void emptyAttributesCollectionTest() {
-    Optional<ItemAttribute> attribute = ItemInfoUtils.extractAttribute(Collections.emptyList(),
-        "key");
+    Optional<ItemAttribute> attribute = ItemInfoUtils.extractAttribute(Collections.emptyList(), "key");
     assertTrue(attribute.isEmpty());
   }
 
@@ -70,23 +74,20 @@ class ItemInfoUtilsTest {
 
   @Test
   void nullAttributeResourceCollectionTest() {
-    Optional<ItemAttributeResource> itemAttributeResource = ItemInfoUtils.extractAttributeResource(
-        null, "key");
+    Optional<ItemAttributeResource> itemAttributeResource = ItemInfoUtils.extractAttributeResource(null, "key");
     assertTrue(itemAttributeResource.isEmpty());
   }
 
   @Test
   void emptyAttributeResourcesCollectionTest() {
-    Optional<ItemAttributeResource> itemAttributeResource = ItemInfoUtils.extractAttributeResource(
-        Collections.emptyList(), "key");
+    Optional<ItemAttributeResource> itemAttributeResource = ItemInfoUtils.extractAttributeResource(Collections.emptyList(), "key");
     assertTrue(itemAttributeResource.isEmpty());
   }
 
   @Test
   void shouldFindAttributeResource() {
     String key = "key1";
-    Optional<ItemAttributeResource> itemAttributeResource = ItemInfoUtils.extractAttributeResource(
-        getAttributeResources(), key);
+    Optional<ItemAttributeResource> itemAttributeResource = ItemInfoUtils.extractAttributeResource(getAttributeResources(), key);
     assertTrue(itemAttributeResource.isPresent());
     assertEquals(key, itemAttributeResource.get().getKey());
   }
@@ -94,9 +95,89 @@ class ItemInfoUtilsTest {
   @Test
   void shouldNotFindAttributeResource() {
     String key = "not-exist";
-    Optional<ItemAttributeResource> itemAttributeResource = ItemInfoUtils.extractAttributeResource(
-        getAttributeResources(), key);
+    Optional<ItemAttributeResource> itemAttributeResource = ItemInfoUtils.extractAttributeResource(getAttributeResources(), key);
     assertTrue(itemAttributeResource.isEmpty());
+  }
+
+  @Test
+  void updateDescriptionTest() {
+    BulkInfoUpdateRQ.Description description = new BulkInfoUpdateRQ.Description();
+    description.setAction(BulkInfoUpdateRQ.Action.UPDATE);
+    description.setComment("new comment");
+    Optional<String> updatedDescription = ItemInfoUtils.updateDescription(description, "existing description");
+    assertTrue(updatedDescription.isPresent());
+    assertEquals("existing description new comment", updatedDescription.get());
+  }
+
+  @Test
+  void createDescriptionTest() {
+    BulkInfoUpdateRQ.Description description = new BulkInfoUpdateRQ.Description();
+    description.setAction(BulkInfoUpdateRQ.Action.CREATE);
+    description.setComment("new comment");
+    Optional<String> updatedDescription = ItemInfoUtils.updateDescription(description, null);
+    assertTrue(updatedDescription.isPresent());
+    assertEquals("new comment", updatedDescription.get());
+  }
+
+  @Test
+  void emptyDescriptionTest() {
+    BulkInfoUpdateRQ.Description description = new BulkInfoUpdateRQ.Description();
+    description.setAction(BulkInfoUpdateRQ.Action.CREATE);
+    Optional<String> updatedDescription = ItemInfoUtils.updateDescription(description, null);
+    assertTrue(updatedDescription.isEmpty());
+  }
+
+  @Test
+  void findAttributeByResourceTest() {
+    Set<ItemAttribute> attributes = new HashSet<>(getAttributes());
+    ItemAttributeResource resource = new ItemAttributeResource("key1", "value1");
+    ItemAttribute attribute = ItemInfoUtils.findAttributeByResource(attributes, resource);
+    assertEquals("key1", attribute.getKey());
+    assertEquals("value1", attribute.getValue());
+  }
+
+  @Test
+  void findAttributeByResourceExceptionTest() {
+    Set<ItemAttribute> attributes = new HashSet<>(getAttributes());
+    ItemAttributeResource resource = new ItemAttributeResource("key4", "value4");
+    assertThrows(ReportPortalException.class, () -> ItemInfoUtils.findAttributeByResource(attributes, resource));
+  }
+
+  @Test
+  void updateAttributeTest() {
+    Set<ItemAttribute> attributes = new HashSet<>(getAttributes());
+    UpdateItemAttributeRQ updateItemAttributeRQ = new UpdateItemAttributeRQ();
+    updateItemAttributeRQ.setFrom(new ItemAttributeResource("key1", "value1"));
+    updateItemAttributeRQ.setTo(new ItemAttributeResource("key1", "newValue"));
+    ItemInfoUtils.updateAttribute(attributes, updateItemAttributeRQ);
+    Optional<ItemAttribute> updatedAttribute = attributes.stream().filter(attr -> "key1".equals(attr.getKey())).findAny();
+    assertTrue(updatedAttribute.isPresent());
+    assertEquals("newValue", updatedAttribute.get().getValue());
+  }
+
+  @Test
+  void updateAttributeExceptionTest() {
+    Set<ItemAttribute> attributes = new HashSet<>(getAttributes());
+    UpdateItemAttributeRQ updateItemAttributeRQ = new UpdateItemAttributeRQ();
+    updateItemAttributeRQ.setFrom(new ItemAttributeResource("key4", "value4"));
+    updateItemAttributeRQ.setTo(new ItemAttributeResource("key4", "newValue"));
+    assertThrows(ReportPortalException.class, () -> ItemInfoUtils.updateAttribute(attributes, updateItemAttributeRQ));
+  }
+
+  @Test
+  void containsAttributeTest() {
+    Set<ItemAttribute> attributes = new HashSet<>(getAttributes());
+    ItemAttributeResource resource = new ItemAttributeResource("key1", "value1");
+    boolean contains = ItemInfoUtils.containsAttribute(attributes, resource);
+    assertTrue(contains);
+  }
+
+  @Test
+  void doesNotContainAttributeTest() {
+    Set<ItemAttribute> attributes = new HashSet<>(getAttributes());
+    ItemAttributeResource resource = new ItemAttributeResource("key4", "value4");
+    boolean contains = ItemInfoUtils.containsAttribute(attributes, resource);
+    assertTrue(!contains);
   }
 
   private List<ItemAttribute> getAttributes() {
@@ -108,7 +189,9 @@ class ItemInfoUtilsTest {
   }
 
   private List<ItemAttributeResource> getAttributeResources() {
-    return Lists.newArrayList(new ItemAttributeResource("key1", "value1"),
-        new ItemAttributeResource("key2", "value2"));
+    return Lists.newArrayList(
+        new ItemAttributeResource("key1", "value1"),
+        new ItemAttributeResource("key2", "value2")
+    );
   }
 }


### PR DESCRIPTION
Added comprehensive unit tests for the ItemInfoUtils class to ensure complete test coverage, including edge cases. The tests cover methods for updating descriptions, finding attributes by resource, updating attributes, checking attribute containment, and extracting attributes from collections. Closes #3.